### PR TITLE
Thomas

### DIFF
--- a/hapla/admix.py
+++ b/hapla/admix.py
@@ -325,7 +325,7 @@ def main(args, deaf):
 	if not args.no_freqs and (args.projection is None):
 		if F > 1: # Save P file for each file (chromosome)
 			for p in np.arange(F):
-				P_tmp = P[c_vec[f_vec[p]]:c_vec[f_vec[p + 1]]].reshape(P_tmp.shape[0]//args.K, args.K)
+				P_tmp = P[c_vec[f_vec[p]]:c_vec[f_vec[p + 1]]].reshape(-1, args.K)
 				np.savetxt(f"{args.out}.K{args.K}.s{args.seed}.{args.prefix}{p + 1}.P", P_tmp, fmt="%.6f")
 			del P_tmp
 			with open(f"{args.out}.K{args.K}.s{args.seed}.pfilelist", "w") as f:

--- a/hapla/main.py
+++ b/hapla/main.py
@@ -187,6 +187,8 @@ def main():
 		metavar="INT", help="Number of initial mini-batches (8)")
 	parser_fatash.add_argument("--admix-check", type=int, default=5,
 		metavar="INT", help="Number of iterations between convergence checks (5)")
+	parser_fatash.add_argument("--simple-transition", action="store_true",
+		help="Use simplified transition probabibilities in HMM")
 
 	# Parse arguments
 	args = parser.parse_args()


### PR DESCRIPTION
Removed reference to P_tmp before it was defined and added printing of posteriors when using fwdbwd (for majority voting the median of posteriors from the majority multiplied by the fraction of agreeing alphas is used). Also added option to use a simpler model of the transition probabilities, though this seems to have very little effect. 